### PR TITLE
adb install doesn’t accept parameters like ‘adb install -rt some.apk’…

### DIFF
--- a/atx/adbkit/mixins.py
+++ b/atx/adbkit/mixins.py
@@ -34,7 +34,7 @@ class RotationWatcherMixin(object):
         if package_name not in out:
             apkpath = os.path.join(__dir__, '..', 'vendor', 'RotationWatcher.apk')
             print 'install rotationwatcher...', apkpath
-            if 0 != self.raw_cmd('install', '-rt', apkpath).wait():
+            if 0 != self.raw_cmd('install', '-r', '-t', apkpath).wait():
                 print 'install rotationwatcher failed.'
                 return
 


### PR DESCRIPTION
adb install不接受“-rt”形式的多参数，macOS下报java异常（java.lang.IllegalArgumentException: No argument expected after "-rt"），windows下报安装失败。fix NetEaseGame/AutomatorX#100